### PR TITLE
Plot cumulative mean log(lambda) for stochastic models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,11 +26,11 @@ Authors@R: c(
     person(given = "Tiffany",
            family = "Knight",
            email = "tiffany.knight@idiv.de",
-           role = "aut")),
+           role = "aut"),
     person(given = "Eric",
            family = "Scott",
            email  = "scottericr@gmail.com",
-           role   = "ctb")
+           role   = "ctb"))
 Description: Flexibly implements Integral Projection Models using a
   mathematical(ish) syntax. This package will not help with the vital rate
   modeling process, but will help convert those regression models into an

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ipmr
 Title: Integral Projection Models
-Version: 0.0.4.9000
+Version: 0.0.4.9001
 Authors@R: c( 
     person(given = "Sam",
            family = "Levin",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,11 @@ Authors@R: c(
     person(given = "Tiffany",
            family = "Knight",
            email = "tiffany.knight@idiv.de",
-           role = "aut"))
+           role = "aut")),
+    person(given = "Eric",
+           family = "Scott",
+           email  = "scottericr@gmail.com",
+           role   = "ctb")
 Description: Flexibly implements Integral Projection Models using a
   mathematical(ish) syntax. This package will not help with the vital rate
   modeling process, but will help convert those regression models into an

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# ipmr (development version)
+
 # ipmr 0.0.5
 
 Contains some tweaks and a number of bug fixes. The latter are mostly related to PADRINO models, and shouldn't have *too much* of an effect on existing user-specified IPMs.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,5 @@
 # ipmr (development version)
 
-# ipmr 0.0.5
-
 Contains some tweaks and a number of bug fixes. The latter are mostly related to PADRINO models, and shouldn't have *too much* of an effect on existing user-specified IPMs.
 
 ## Features 
@@ -14,6 +12,8 @@ Contains some tweaks and a number of bug fixes. The latter are mostly related to
 
 - Depending on your view, this may be a bug fix: updates the `log` argument in `lambda()` so that it only changes the scale, NOT the calculation method. The prior behavior was documented, but unlikely to be intuitive, and so caused some confusion. Thanks to @aariq for pointing this out. 
 
+- For stochastic IPMs, `is_conv_to_asymptotic()` and `conv_plot()` now check for convergence in stochastic lambda.  That is, they use a cumulative mean `log(lambda)` over iterations after discarding a burn-in.
+
 ## Bug fixes 
 
  - Fixes bug in normalization of left/right eigenvectors in simple density independent stochastic models. (thanks to @aariq)
@@ -21,6 +21,8 @@ Contains some tweaks and a number of bug fixes. The latter are mostly related to
  - Fixes bug where `"drop_levels"` was not recognized in some parameter set indexed models.
  
  - Fixes bug where parameter set levels were recycled in some cases. 
+ 
+ - Fixes bug in `lambda()` where `log = TRUE` had no effect when the IPM was stochastic and `type_lambda` was `'last'` or `'all'`.
 
 # ipmr 0.0.4
 

--- a/R/internal-lin_alg.R
+++ b/R/internal-lin_alg.R
@@ -498,7 +498,7 @@ is_square <- function(x) {
 #' visually. \code{is_conv_to_asymptotic} checks whether
 #' \code{lambda[iterations - 1]} equals \code{lambda[iterations]} within the
 #' specified tolerance, \code{tolerance}. \code{conv_plot} plots the time series of
-#' \code{lambda} (or \code{log(lambda)}. For stochastic models, a running mean of
+#' \code{lambda} (or \code{log(lambda)}). For stochastic models, a cumulative mean of
 #' log(lambda) is used to check for convergence.
 #'
 #' @param ipm An object returned by \code{make_ipm()}.

--- a/R/utils-export.R
+++ b/R/utils-export.R
@@ -1666,8 +1666,11 @@ conv_plot.ipmr_ipm <- function(ipm, iterations = NULL,
               "'log = FALSE' to plot on a linear scale.")
     }
     all_lams <- lambda(ipm, type_lambda = "all", log = TRUE)
+    #store iteration# as rownames so correct after burn_in removed
+    row.names(all_lams) <- seq_len(nrow(all_lams))
     burn_ind <- seq_len(round(length(all_lams) * burn_in))
     temp <- all_lams[-burn_ind, , drop = FALSE]
+
     for(i in 1:ncol(temp)) {
       temp[ , i] <- cumsum(temp[,i])/1:nrow(temp)
     }
@@ -1685,6 +1688,7 @@ conv_plot.ipmr_ipm <- function(ipm, iterations = NULL,
     }
 
     all_lams <- lambda(ipm, type_lambda = "all", log = log)
+    row.names(all_lams) <- seq_len(nrow(all_lams))
 
   }
   nms      <- colnames(all_lams)
@@ -1692,16 +1696,15 @@ conv_plot.ipmr_ipm <- function(ipm, iterations = NULL,
   dots     <- list(...)
 
   if(is.null(iterations)) {
-
-    iterations <- seq(1, nrow(all_lams), by = 1)
+    iterations <- as.numeric(row.names(all_lams))
   }
 
-  all_lams <- all_lams[iterations, , drop = FALSE]
+  all_lams <- all_lams[row.names(all_lams) %in% iterations, , drop = FALSE]
 
   if(!"type" %in% names(dots)) {
     dots$type <- "l"
   }
-#TODO: for stochastic models y axis should be "Cumulattive Mean Log(lambda)"
+
   if(grepl("_stoch_", class(ipm)[1])) {
     if(log) {
       y_nm <- expression(paste("Cumulative Mean Log(  ", lambda, ")"))

--- a/R/utils-export.R
+++ b/R/utils-export.R
@@ -1621,13 +1621,16 @@ make_iter_kernel.ipmr_ipm <- function(ipm,
   return(out)
 
 }
-#TODO: add burn_in param and description, add explanation of what is plotted for stochastic models.
 #' @rdname check_convergence
 #' @param iterations The range of iterations to plot \code{lambda} for. The default
 #' is every iteration.
-#' @param log A logical indicating whether log transform \code{lambda}.
+#' @param log A logical indicating whether to log transform \code{lambda}. This
+#'   defaults to TRUE for stochastic models and FALSE for deterministic models.
 #' @param show_stable A logical indicating whether or not to draw a line indicating
 #' population stability at \code{lambda = 1}.
+#' @param burn_in The proportion of iterations to discard. Default is 0.1 (i.e.
+#'   first 10\% of iterations in the simulation). Ignored for deterministic
+#'   models.
 #' @param ... Further arguments to \code{plot}.
 #'
 #' @details Plotting can be controlled by passing additional graphing parameters
@@ -1647,7 +1650,7 @@ make_iter_kernel.ipmr_ipm <- function(ipm,
 #'
 #' @export
 
-conv_plot <- function(ipm, iterations, log, show_stable, ...) {
+conv_plot <- function(ipm, iterations, log, show_stable, burn_in, ...) {
   UseMethod("conv_plot")
 }
 

--- a/R/utils-export.R
+++ b/R/utils-export.R
@@ -1621,7 +1621,7 @@ make_iter_kernel.ipmr_ipm <- function(ipm,
   return(out)
 
 }
-
+#TODO: add burn_in param and description, add explanation of what is plotted for stochastic models.
 #' @rdname check_convergence
 #' @param iterations The range of iterations to plot \code{lambda} for. The default
 #' is every iteration.
@@ -1701,15 +1701,24 @@ conv_plot.ipmr_ipm <- function(ipm, iterations = NULL,
   if(!"type" %in% names(dots)) {
     dots$type <- "l"
   }
+#TODO: for stochastic models y axis should be "Cumulattive Mean Log(lambda)"
+  if(grepl("_stoch_", class(ipm)[1])) {
+    if(log) {
+      y_nm <- expression(paste("Cumulative Mean Log(  ", lambda, ")"))
+      nms  <- paste("Log(", nms, ")", sep = "")
+    } else {
+      y_nm <- expression(paste("Cumulative Mean   ", lambda))
+    }
 
-  if(log) {
-    y_nm <- expression(paste("Single Time Step Log(  ", lambda, ")"))
-    nms  <- paste("Log(", nms, ")", sep = "")
-    # all_lams <- apply(all_lams, MARGIN = 2, FUN = log)
   } else {
-    y_nm <- expression(paste("Single Time Step   ", lambda))
-  }
-
+    if(log) {
+      y_nm <- expression(paste("Single Time Step Log(  ", lambda, ")"))
+      nms  <- paste("Log(", nms, ")", sep = "")
+      # all_lams <- apply(all_lams, MARGIN = 2, FUN = log)
+    } else {
+      y_nm <- expression(paste("Single Time Step   ", lambda))
+    }
+}
   for(i in seq_len(ncol(all_lams))) {
 
     if(!"main" %in% names(dots)) dots$main <- nms[i]

--- a/man/check_convergence.Rd
+++ b/man/check_convergence.Rd
@@ -8,22 +8,31 @@
 \usage{
 is_conv_to_asymptotic(ipm, tolerance, burn_in)
 
-conv_plot(ipm, iterations, log, show_stable, ...)
+conv_plot(ipm, iterations, log, show_stable, burn_in, ...)
 
-\method{conv_plot}{ipmr_ipm}(ipm, iterations = NULL, log = FALSE, show_stable = TRUE, ...)
+\method{conv_plot}{ipmr_ipm}(
+  ipm,
+  iterations = NULL,
+  log = NULL,
+  show_stable = TRUE,
+  burn_in = 0.1,
+  ...
+)
 }
 \arguments{
 \item{ipm}{An object returned by \code{make_ipm()}.}
 
 \item{tolerance}{The tolerance for convergence.}
 
-\item{burn_in}{The proportion of iterations to discard. Default is 0.1
-(i.e. first 10\% of iterations in the simulation). Ignored for deterministic models.}
+\item{burn_in}{The proportion of iterations to discard. Default is 0.1 (i.e.
+first 10\% of iterations in the simulation). Ignored for deterministic
+models.}
 
 \item{iterations}{The range of iterations to plot \code{lambda} for. The default
 is every iteration.}
 
-\item{log}{A logical indicating whether log transform \code{lambda}.}
+\item{log}{A logical indicating whether to log transform \code{lambda}. This
+defaults to TRUE for stochastic models and FALSE for deterministic models.}
 
 \item{show_stable}{A logical indicating whether or not to draw a line indicating
 population stability at \code{lambda = 1}.}
@@ -39,7 +48,7 @@ Checks for convergence to asymptotic dynamics numerically and
 visually. \code{is_conv_to_asymptotic} checks whether
 \code{lambda[iterations - 1]} equals \code{lambda[iterations]} within the
 specified tolerance, \code{tolerance}. \code{conv_plot} plots the time series of
-\code{lambda} (or \code{log(lambda)}. For stochastic models, a running mean of
+\code{lambda} (or \code{log(lambda)}). For stochastic models, a cumulative mean of
 log(lambda) is used to check for convergence.
 }
 \details{


### PR DESCRIPTION
This addresses issue #42 by changing `conv_plot()` to calculate a stochastic lambda (cumulative mean log(lambda)) to plot.  Cumulative mean is calculated _after_ discarding `burn_in` iterations.  It plots the actual iteration number starting at whatever iteration wasn't thrown out by `burn_in`.