### PR TITLE
Simple fixes to `check_convergence` docs

### DIFF
--- a/R/internal-lin_alg.R
+++ b/R/internal-lin_alg.R
@@ -518,7 +518,7 @@ is_conv_to_asymptotic <- function(ipm, tolerance, burn_in) {
 #' @rdname check_convergence
 #' @export
 
-is_conv_to_asymptotic.ipmr_ipm <- function(ipm, tolerance = 1e-10, burn_in = 0.1) {
+is_conv_to_asymptotic.ipmr_ipm <- function(ipm, tolerance = 1e-6, burn_in = 0.1) {
 
   pop_state_test <- vapply(ipm$pop_state,
                            function(x) ! any(is.na(x)),

--- a/R/internal-lin_alg.R
+++ b/R/internal-lin_alg.R
@@ -515,6 +515,7 @@ is_conv_to_asymptotic <- function(ipm, tolerance, burn_in) {
   UseMethod("is_conv_to_asymptotic")
 }
 
+#' @rdname check_convergence
 #' @export
 
 is_conv_to_asymptotic.ipmr_ipm <- function(ipm, tolerance = 1e-10, burn_in = 0.1) {

--- a/R/utils-export.R
+++ b/R/utils-export.R
@@ -1645,7 +1645,7 @@ make_iter_kernel.ipmr_ipm <- function(ipm,
 #'
 #' ipm <- make_ipm(proto)
 #'
-#' is_conv_to_asymptotic(ipm, tol = 1e-5)
+#' is_conv_to_asymptotic(ipm, tolerance = 1e-5)
 #' conv_plot(ipm)
 #'
 #' @export

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -9,7 +9,7 @@ articles:
   index-notation: index-notation.html
   ipmr-introduction: ipmr-introduction.html
   proto-ipms: proto-ipms.html
-last_built: 2022-02-09T18:16Z
+last_built: 2022-01-11T16:33Z
 urls:
   reference: https://levisc8.github.io/ipmr/reference
   article: https://levisc8.github.io/ipmr/articles

--- a/man/check_convergence.Rd
+++ b/man/check_convergence.Rd
@@ -9,7 +9,7 @@
 \usage{
 is_conv_to_asymptotic(ipm, tolerance, burn_in)
 
-\method{is_conv_to_asymptotic}{ipmr_ipm}(ipm, tolerance = 1e-10, burn_in = 0.1)
+\method{is_conv_to_asymptotic}{ipmr_ipm}(ipm, tolerance = 1e-06, burn_in = 0.1)
 
 conv_plot(ipm, iterations, log, show_stable, burn_in, ...)
 

--- a/man/check_convergence.Rd
+++ b/man/check_convergence.Rd
@@ -2,11 +2,14 @@
 % Please edit documentation in R/internal-lin_alg.R, R/utils-export.R
 \name{is_conv_to_asymptotic}
 \alias{is_conv_to_asymptotic}
+\alias{is_conv_to_asymptotic.ipmr_ipm}
 \alias{conv_plot}
 \alias{conv_plot.ipmr_ipm}
 \title{Check for model convergence to asymptotic dynamics}
 \usage{
 is_conv_to_asymptotic(ipm, tolerance, burn_in)
+
+\method{is_conv_to_asymptotic}{ipmr_ipm}(ipm, tolerance = 1e-10, burn_in = 0.1)
 
 conv_plot(ipm, iterations, log, show_stable, burn_in, ...)
 
@@ -64,7 +67,7 @@ proto <- gen_di_det_ex$proto_ipm \%>\%
 
 ipm <- make_ipm(proto)
 
-is_conv_to_asymptotic(ipm, tol = 1e-5)
+is_conv_to_asymptotic(ipm, tolerance = 1e-5)
 conv_plot(ipm)
 
 }


### PR DESCRIPTION
The `ipmr_ipm` method for `is_conv_to_asymptotic()` wasn't showing up in the documentation, so the default for `tolerance` wasn't visible.

While this PR is open, it seems like maybe 1e-10 is overly strict of a default.  I see you used 1e-5 in your example---should the default value maybe be changed?